### PR TITLE
Allow arbitrary extra flags for node-exporter

### DIFF
--- a/node-exporter.tf
+++ b/node-exporter.tf
@@ -13,11 +13,12 @@ data "ignition_file" "static-metrics" {
 data "ignition_systemd_unit" "node-exporter" {
   name = "node-exporter.service"
 
-  content = templatefile("${path.module}/templates/node-exporter.service",
+  content = templatefile("${path.module}/templates/node-exporter.service.tpl",
     {
       node_exporter_image_url = var.node_exporter_image_url
       node_exporter_image_tag = var.node_exporter_image_tag
       collector_dir           = var.collector_dir
+      extra_flags             = var.extra_flags
     }
   )
 }

--- a/templates/node-exporter.service.tpl
+++ b/templates/node-exporter.service.tpl
@@ -6,6 +6,7 @@ After=docker.socket
 ExecStartPre=-/bin/sh -c 'docker kill "$(docker ps -q --filter=name=%p_)"'
 ExecStartPre=-/bin/sh -c 'docker rm "$(docker ps -q --filter=name=%p_)"'
 ExecStartPre=-/usr/bin/mkdir -p /etc/prom-text-collectors
+# /run/dbus/system_bus_socket mount for --collector.systemd
 ExecStart=/bin/sh -c "\
     /usr/bin/docker run --rm \
       --name %p_$(uuidgen) \
@@ -13,8 +14,9 @@ ExecStart=/bin/sh -c "\
       --net=host \
       --pid=host \
       -v /:/host:ro,rslave \
+      -v /run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:ro \
       ${node_exporter_image_url}:${node_exporter_image_tag} \
-        --path.rootfs /host ${collector_dir == "" ? "" : "--collector.textfile.directory=/host${collector_dir}"}"
+        --path.rootfs /host ${collector_dir == "" ? "" : "--collector.textfile.directory=/host${collector_dir}"} ${extra_flags == "" ? "" : "${extra_flags}"}"
 ExecStop=-/bin/sh -c 'docker stop -t 3 "$(docker ps -q --filter=name=%p_)"'
 Restart=on-failure
 RestartSec=60

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,8 @@ variable "node_exporter_image_tag" {
   description = "The version of the node_exporter image to use."
   default     = "v1.3.1"
 }
+
+variable "extra_flags" {
+  default = ""
+  type    = string
+}


### PR DESCRIPTION
In this case we'll enable systemd collector to monitor unit status,
previously wiresteward was down due to s3fs unable to run as AWS
credentials got disabled. Therefore we are also adding a new dbus mount
for the collector to work.
